### PR TITLE
chore: bump Android API target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,8 @@ jobs:
 
       - name: Download Android Emulator Image
         run: |
-          echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-29;default;x86"
-          echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd --force --name emu --device pixel --package 'system-images;android-29;default;x86'
+          echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-30;default;x86_64"
+          echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd --force --name emu --device pixel --package 'system-images;android-30;default;x86_64'
           $ANDROID_HOME/emulator/emulator -list-avds
 
       - name: Create debug keystore

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.3"
-        minSdkVersion = 29
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        buildToolsVersion = "30.0.2"
+        minSdkVersion = 30
+        compileSdkVersion = 30
+        targetSdkVersion = 30
         supportLibVersion = "28.0.0"
         ndkVersion = "21.4.7075529"
         // kotlinVersion = "1.3.10"

--- a/ci/install-android-tools.sh
+++ b/ci/install-android-tools.sh
@@ -24,8 +24,8 @@ echo "d975f751698a77b662f1254ddbeed3901e976f5a" > "$ANDROID_SDK_ROOT/licenses/in
 SDKMANAGER=$ANDROID_SDK_ROOT/tools/bin/sdkmanager
 
 $SDKMANAGER "platform-tools"
-$SDKMANAGER "platforms;android-29"
-$SDKMANAGER "build-tools;29.0.2"
+$SDKMANAGER "platforms;android-30"
+$SDKMANAGER "build-tools;30.0.2"
 $SDKMANAGER "ndk-bundle"
-$SDKMANAGER "system-images;android-29;default;x86_64"
+$SDKMANAGER "system-images;android-30;default;x86_64"
 $SDKMANAGER "emulator"


### PR DESCRIPTION
Fixing [this issue seen during an attempted beta deploy](https://github.com/theliturgists/app/runs/4664107130?check_suite_focus=true):

```
Google Api Error: forbidden: Your app currently targets API level 29 and must target at least API level 30.
```