### PR TITLE
ci: pass PR ref from actions event payload

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -12,4 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: ./ci/unpublish-expo-release-channel.sh
+        with:
+          ref: ${github.pull_request.base.ref}
+      - run: ./ci/unpublish-expo-release-channel.sh ${github.pull_request.head.ref}

--- a/ci/unpublish-expo-release-channel.sh
+++ b/ci/unpublish-expo-release-channel.sh
@@ -2,8 +2,8 @@
 
 source $(dirname $0)/common.inc
 
-validate_required_env_vars GITHUB_REF
-channel=$(get_release_channel ${GITHUB_REF})
+github_ref=$1
+channel=$(get_release_channel ${github_ref})
 
 # Here's where we'd unpublish the release channel if we could...
 # ...but expo doesn't provide a way to do that, for some reason.


### PR DESCRIPTION
`GITHUB_REF` is always 'master' on the 'close pull request' action, so we pull the source branch name
from the action event payload instead.