### PR TITLE
ci: make post-merge checkout use PR ref

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -13,5 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Use the PR ref here, which exists even after the branch is deleted
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+
+      # Here, however, we need the branch name, since that's what we use
+      # to name the expo release channel
       - run: ./ci/unpublish-expo-release-channel.sh ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
So that checkout succeeds even if the branch is gone.